### PR TITLE
Altera o construtor gerado pelo snippet getmodel, para que as propriedades sejam inicializadas.

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -571,7 +571,7 @@
             "\tint id;",
             "\tString name;",
             "",
-            "\t$1Model({ id, name });",
+            "\t$1Model({ this.id, this.name });",
             "",
             "\t$1Model.fromJson(Map<String, dynamic> json){",
             "\t\t\tthis.id = json['id'];",


### PR DESCRIPTION
Sugiro que o construtor gerado pelo snippet getmodel seja alterado com this.id e this.name para que as propriedades do objeto sejam inicializadas no momento da instanciação da classe.